### PR TITLE
Add HttpResponseTelemetryInitializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,11 @@ await telemetryClient.ExecuteAsRequestAsync(new ExecuteAsRequestAsyncOptions(ope
 * `Action<IOperationHolder<RequestTelemetry>>? Configure` - if more telemetry details need to be added. Is called right before operations itself
 * `int? FlushWait` - time for telemetry to be pushed. Usefull for console apps. In secondss - default 15
 * `Action? PostExecute` - is called after an operation just before operation.Dispose(). That means logs will still be attached to the RequestTelemetry and method execution time will be included
+
+## HttpResponseTelemetryInitializer
+Enrich telemetry with response content to dependency http requests.
+```
+services.AddSingleton<ITelemetryInitializer>(
+    new HttpResponseTelemetryInitializer(
+        c => c.StatusCode >= HttpStatusCode.BadRequest))
+```

--- a/src/Likvido.ApplicationInsights.Telemetry/Extensions/OperationTelemetryExtensions.cs
+++ b/src/Likvido.ApplicationInsights.Telemetry/Extensions/OperationTelemetryExtensions.cs
@@ -8,10 +8,10 @@ namespace Likvido.ApplicationInsights.Telemetry
         private const int PropertyMaxLength = 8192;
 
         /// <summary>
-        /// Split long property values in chuncks.
+        /// Split long property values in chunks.
         /// Appinsights has a property length limit.
         /// </summary>
-        public static void AddChunckedCustomProperty(this OperationTelemetry telemetry, string key, string value)
+        public static void AddChunkedCustomProperty(this OperationTelemetry telemetry, string key, string value)
         {
             if (telemetry == null || value == null)
             {
@@ -25,9 +25,9 @@ namespace Likvido.ApplicationInsights.Telemetry
             else
             {
                 for (
-                    int i = 1, chunckStart = 0;
-                    i < 4 && chunckStart < value.Length;
-                    i++, chunckStart += PropertyMaxLength)
+                    int i = 1, chunkStart = 0;
+                    i < 4 && chunkStart < value.Length;
+                    i++, chunkStart += PropertyMaxLength)
                 {
                     telemetry.Properties.Add($"{key}-{i}", value.Substring(i, Math.Min(PropertyMaxLength, value.Length - i)));
                 }

--- a/src/Likvido.ApplicationInsights.Telemetry/Extensions/OperationTelemetryExtensions.cs
+++ b/src/Likvido.ApplicationInsights.Telemetry/Extensions/OperationTelemetryExtensions.cs
@@ -24,29 +24,30 @@ namespace Likvido.ApplicationInsights.Telemetry
             var lengthLeft = CustomPropertiesTotalMaxLength;
             foreach (var prop in chunkedProperties)
             {
-                // Index property keys.
-                var propKey = prop.Index == 1
-                    ? prop.Key
-                    : $"{prop.Key}-{prop.Index}";
-
                 // Trim value if total length exeeded.
                 var propValue = lengthLeft < prop.Value.Length
                     ? $"{prop.Value.Substring(0, Math.Max(lengthLeft, 0))}\n--trimmed"
                     : prop.Value;
 
-                telemetry.Properties.Add(propKey, propValue);
+                telemetry.Properties.Add(prop.Key, propValue);
                 lengthLeft -= prop.Value.Length;
             }
         }
 
-        private static IEnumerable<(string Key, int Index, string Value)> ChunkProperty((string Key, string Value) prop)
+        private static IEnumerable<(string Key, string Value)> ChunkProperty((string Key, string Value) prop)
         {
+            if (prop.Value.Length < PropertyValueMaxLength)
+            {
+                yield return prop;
+                yield break;
+            }
+
             for (
                 int chunkStart = 0, i = 1;
                 chunkStart < prop.Value.Length;
                 chunkStart += PropertyValueMaxLength, i++)
             {
-                yield return (prop.Key, i, prop.Value.Substring(chunkStart, Math.Min(PropertyValueMaxLength, prop.Value.Length - chunkStart)));
+                yield return ($"{prop.Key}_{i}", prop.Value.Substring(chunkStart, Math.Min(PropertyValueMaxLength, prop.Value.Length - chunkStart)));
             }
         }
     }

--- a/src/Likvido.ApplicationInsights.Telemetry/Extensions/OperationTelemetryExtensions.cs
+++ b/src/Likvido.ApplicationInsights.Telemetry/Extensions/OperationTelemetryExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+
+namespace Likvido.ApplicationInsights.Telemetry
+{
+    internal static class OperationTelemetryExtensions
+    {
+        private const int PropertyMaxLength = 8192;
+
+        /// <summary>
+        /// Split long property values in chuncks.
+        /// Appinsights has a property length limit.
+        /// </summary>
+        public static void AddChunckedCustomProperty(this OperationTelemetry telemetry, string key, string value)
+        {
+            if (telemetry == null || value == null)
+            {
+                return;
+            }
+
+            if (value.Length <= PropertyMaxLength)
+            {
+                telemetry.Properties.Add(key, value);
+            }
+            else
+            {
+                for (
+                    int i = 1, chunckStart = 0;
+                    i < 4 && chunckStart < value.Length;
+                    i++, chunckStart += PropertyMaxLength)
+                {
+                    telemetry.Properties.Add($"{key}-{i}", value.Substring(i, Math.Min(PropertyMaxLength, value.Length - i)));
+                }
+            }
+        }
+    }
+}

--- a/src/Likvido.ApplicationInsights.Telemetry/Extensions/OperationTelemetryExtensions.cs
+++ b/src/Likvido.ApplicationInsights.Telemetry/Extensions/OperationTelemetryExtensions.cs
@@ -29,7 +29,7 @@ namespace Likvido.ApplicationInsights.Telemetry
                     i < 4 && chunkStart < value.Length;
                     i++, chunkStart += PropertyMaxLength)
                 {
-                    telemetry.Properties.Add($"{key}-{i}", value.Substring(i, Math.Min(PropertyMaxLength, value.Length - i)));
+                    telemetry.Properties.Add($"{key}-{i}", value.Substring(chunkStart, Math.Min(PropertyMaxLength, value.Length - chunkStart)));
                 }
             }
         }

--- a/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseCustomProperty.cs
+++ b/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseCustomProperty.cs
@@ -1,0 +1,8 @@
+﻿namespace Likvido.ApplicationInsights.Telemetry
+{
+    public enum HttpResponseCustomProperty
+    {
+        ResponseContent,
+        RequestContent
+    }
+}

--- a/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseTelemetryConditionInfo.cs
+++ b/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseTelemetryConditionInfo.cs
@@ -1,4 +1,6 @@
 ﻿using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using Microsoft.ApplicationInsights.DataContracts;
 
 namespace Likvido.ApplicationInsights.Telemetry
@@ -8,15 +10,21 @@ namespace Likvido.ApplicationInsights.Telemetry
         public DependencyTelemetry Telemetry { get; set; }
         public HttpResponseCustomProperty Property { get; set; }
         public HttpStatusCode StatusCode { get; set; }
+        public HttpMethod Method { get; set; }
+        public HttpContentHeaders ContentHeaders { get; set; }
 
         public HttpResponseTelemetryConditionInfo(
             DependencyTelemetry telemetry,
             HttpResponseCustomProperty property,
-            HttpStatusCode statusCode)
+            HttpStatusCode statusCode,
+            HttpMethod method,
+            HttpContentHeaders contentHeaders)
         {
             Telemetry = telemetry;
             Property = property;
             StatusCode = statusCode;
+            Method = method;
+            ContentHeaders = contentHeaders;
         }
     }
 }

--- a/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseTelemetryConditionInfo.cs
+++ b/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseTelemetryConditionInfo.cs
@@ -1,0 +1,22 @@
+﻿using System.Net;
+using Microsoft.ApplicationInsights.DataContracts;
+
+namespace Likvido.ApplicationInsights.Telemetry
+{
+    public class HttpResponseTelemetryConditionInfo
+    {
+        public DependencyTelemetry Telemetry { get; set; }
+        public HttpResponseCustomProperty Property { get; set; }
+        public HttpStatusCode StatusCode { get; set; }
+
+        public HttpResponseTelemetryConditionInfo(
+            DependencyTelemetry telemetry,
+            HttpResponseCustomProperty property,
+            HttpStatusCode statusCode)
+        {
+            Telemetry = telemetry;
+            Property = property;
+            StatusCode = statusCode;
+        }
+    }
+}

--- a/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseTelemetryInitializer.cs
+++ b/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseTelemetryInitializer.cs
@@ -37,24 +37,22 @@ namespace Likvido.ApplicationInsights.Telemetry
         private void Initialize(DependencyTelemetry telemetry)
         {
             // Check if telemetry is for http response.
-            if (telemetry.Type != "Http" ||
-                !telemetry.TryGetOperationDetail("HttpResponse", out var httpResponseObj) ||
-                !(httpResponseObj is HttpResponseMessage httpResponse))
+            if (telemetry.Type == "Http" &&
+                telemetry.TryGetOperationDetail("HttpResponse", out var httpResponseObj) &&
+                httpResponseObj is HttpResponseMessage httpResponse)
             {
-                return;
+                TryEnrichWithContentProperty(
+                    telemetry,
+                    httpResponse.StatusCode,
+                    HttpResponseCustomProperty.ResponseContent,
+                    httpResponse.Content);
+
+                TryEnrichWithContentProperty(
+                    telemetry,
+                    httpResponse.StatusCode,
+                    HttpResponseCustomProperty.RequestContent,
+                    httpResponse.RequestMessage.Content);
             }
-
-            TryEnrichWithContentProperty(
-                telemetry,
-                httpResponse.StatusCode,
-                HttpResponseCustomProperty.ResponseContent,
-                httpResponse.Content);
-
-            TryEnrichWithContentProperty(
-                telemetry,
-                httpResponse.StatusCode,
-                HttpResponseCustomProperty.RequestContent,
-                httpResponse.RequestMessage.Content);
         }
 
         private void TryEnrichWithContentProperty(
@@ -66,7 +64,7 @@ namespace Likvido.ApplicationInsights.Telemetry
             if (_condition(new HttpResponseTelemetryConditionInfo(telemetry, property, statusCode)) &&
                 TryReadContentString(content, out var contentString))
             {
-                telemetry.AddChunckedCustomProperty(property.ToString(), contentString!);
+                telemetry.AddChunkedCustomProperty(property.ToString(), contentString!);
             }
         }
 

--- a/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseTelemetryInitializer.cs
+++ b/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseTelemetryInitializer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
-using System.Net;
+using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -14,9 +15,24 @@ namespace Likvido.ApplicationInsights.Telemetry
     {
         private readonly Func<HttpResponseTelemetryConditionInfo, bool> _condition;
 
-        public HttpResponseTelemetryInitializer(Func<HttpResponseTelemetryConditionInfo, bool> condition)
+        public List<string> ContentMediaTypes { get; } = new List<string>
+        {
+            "application/json",
+            "text/plain",
+            "text/html"
+        };
+
+        public HttpResponseTelemetryInitializer(
+            Func<HttpResponseTelemetryConditionInfo, bool> condition)
         {
             _condition = condition ?? throw new ArgumentNullException(nameof(condition));
+        }
+
+        public HttpResponseTelemetryInitializer(
+            Func<HttpResponseTelemetryConditionInfo, bool> condition,
+            List<string> contentMediaTypes) : this(condition)
+        {
+            ContentMediaTypes = contentMediaTypes;
         }
 
         public void Initialize(ITelemetry telemetry)
@@ -41,50 +57,56 @@ namespace Likvido.ApplicationInsights.Telemetry
                 telemetry.TryGetOperationDetail("HttpResponse", out var httpResponseObj) &&
                 httpResponseObj is HttpResponseMessage httpResponse)
             {
-                TryEnrichWithContentProperty(
-                    telemetry,
-                    httpResponse.StatusCode,
-                    HttpResponseCustomProperty.ResponseContent,
-                    httpResponse.Content);
+                var properties = new List<(string Key, string Value)>();
 
-                TryEnrichWithContentProperty(
-                    telemetry,
-                    httpResponse.StatusCode,
-                    HttpResponseCustomProperty.RequestContent,
-                    httpResponse.RequestMessage.Content);
-            }
-        }
+                if (httpResponse.RequestMessage.Content != null &&
+                    IsValidMediaType(httpResponse.RequestMessage.Content.Headers) &&
+                    _condition(new HttpResponseTelemetryConditionInfo(
+                        telemetry,
+                        HttpResponseCustomProperty.RequestContent,
+                        httpResponse.StatusCode,
+                        httpResponse.RequestMessage.Method,
+                        httpResponse.RequestMessage.Content.Headers)) &&
+                    TryReadContentString(httpResponse.RequestMessage.Content, out var requestContentString))
+                {
+                    properties.Add((HttpResponseCustomProperty.RequestContent.ToString(), requestContentString!));
+                }
 
-        private void TryEnrichWithContentProperty(
-            DependencyTelemetry telemetry,
-            HttpStatusCode statusCode,
-            HttpResponseCustomProperty property,
-            HttpContent content)
-        {
-            if (_condition(new HttpResponseTelemetryConditionInfo(telemetry, property, statusCode)) &&
-                TryReadContentString(content, out var contentString))
-            {
-                telemetry.AddChunkedCustomProperty(property.ToString(), contentString!);
+                if (httpResponse.Content != null &&
+                    IsValidMediaType(httpResponse.Content.Headers) &&
+                    _condition(new HttpResponseTelemetryConditionInfo(
+                        telemetry,
+                        HttpResponseCustomProperty.ResponseContent,
+                        httpResponse.StatusCode,
+                        httpResponse.RequestMessage.Method,
+                        httpResponse.Content.Headers)) &&
+                    TryReadContentString(httpResponse.Content, out var responseContentString))
+                {
+                    properties.Add((HttpResponseCustomProperty.ResponseContent.ToString(), responseContentString!));
+                }
+
+                telemetry.AddCustomProperties(properties);
             }
         }
 
         private static bool TryReadContentString(HttpContent content, out string? contentString)
         {
-            if (content != null)
+            try
             {
-                try
-                {
-                    contentString = content.ReadAsStringAsync().GetAwaiter().GetResult();
-                    return true;
-                }
-                catch
-                {
-                    // Failed to read content string.
-                }
+                contentString = content.ReadAsStringAsync().GetAwaiter().GetResult();
+                return true;
             }
+            catch (Exception ex)
+            {
+                contentString = $"-- Failed to read content: {ex.Message}";
+                return false;
+            }
+        }
 
-            contentString = null;
-            return false;
+        private bool IsValidMediaType(HttpContentHeaders contentHeaders)
+        {
+            return contentHeaders?.ContentType?.MediaType != null &&
+                ContentMediaTypes.Contains(contentHeaders.ContentType.MediaType);
         }
     }
 }

--- a/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseTelemetryInitializer.cs
+++ b/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseTelemetryInitializer.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Likvido.ApplicationInsights.Telemetry
+{
+    /// <summary>
+    /// Enrich telemetry with response content.
+    /// </summary>
+    public class HttpResponseTelemetryInitializer : ITelemetryInitializer
+    {
+        private readonly Func<HttpResponseTelemetryConditionInfo, bool> _condition;
+
+        public HttpResponseTelemetryInitializer(Func<HttpResponseTelemetryConditionInfo, bool> condition)
+        {
+            _condition = condition ?? throw new ArgumentNullException(nameof(condition));
+        }
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            try
+            {
+                if (telemetry is DependencyTelemetry dependencyTelemetry)
+                {
+                    Initialize(dependencyTelemetry);
+                }
+            }
+            catch
+            {
+                // Do not fail initializer.
+            }
+        }
+
+        private void Initialize(DependencyTelemetry telemetry)
+        {
+            // Check if telemetry is for http response.
+            if (telemetry.Type != "Http" ||
+                !telemetry.TryGetOperationDetail("HttpResponse", out var httpResponseObj) ||
+                !(httpResponseObj is HttpResponseMessage httpResponse))
+            {
+                return;
+            }
+
+            TryEnrichWithContentProperty(
+                telemetry,
+                httpResponse.StatusCode,
+                HttpResponseCustomProperty.ResponseContent,
+                httpResponse.Content);
+
+            TryEnrichWithContentProperty(
+                telemetry,
+                httpResponse.StatusCode,
+                HttpResponseCustomProperty.RequestContent,
+                httpResponse.RequestMessage.Content);
+        }
+
+        private void TryEnrichWithContentProperty(
+            DependencyTelemetry telemetry,
+            HttpStatusCode statusCode,
+            HttpResponseCustomProperty property,
+            HttpContent content)
+        {
+            if (_condition(new HttpResponseTelemetryConditionInfo(telemetry, property, statusCode)) &&
+                TryReadContentString(content, out var contentString))
+            {
+                telemetry.AddChunckedCustomProperty(property.ToString(), contentString!);
+            }
+        }
+
+        private static bool TryReadContentString(HttpContent content, out string? contentString)
+        {
+            if (content != null)
+            {
+                try
+                {
+                    contentString = content.ReadAsStringAsync().GetAwaiter().GetResult();
+                    return true;
+                }
+                catch
+                {
+                    // Failed to read content string.
+                }
+            }
+
+            contentString = null;
+            return false;
+        }
+    }
+}

--- a/src/version.props
+++ b/src/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Add `HttpResponseTelemetryInitializer` to log response content in custom properties.
Can be configured to log content only for failed requests, or requests to a specific target API.

Example:
![image](https://user-images.githubusercontent.com/10668361/132516210-05ecb2d8-4c9b-46f5-849f-9dc4d04bb3f8.png)
