### PR TITLE
Likvido/Likvido.ApplicationInsights.Telemetry#3 - HttpResponseTelemetryInitializer doesn't respect Http (tracked component)

### DIFF
--- a/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseTelemetryInitializer.cs
+++ b/src/Likvido.ApplicationInsights.Telemetry/HttpResponse/HttpResponseTelemetryInitializer.cs
@@ -53,8 +53,8 @@ namespace Likvido.ApplicationInsights.Telemetry
 
         private void Initialize(DependencyTelemetry telemetry)
         {
-            // Check if telemetry is for http response.
-            if (telemetry.Type == "Http" &&
+            // Check if telemetry is for `Http` or `Http (tracked component)` type response.
+            if (telemetry.Type.StartsWith("Http", StringComparison.Ordinal) &&
                 telemetry.TryGetOperationDetail("HttpResponse", out var httpResponseObj) &&
                 httpResponseObj is HttpResponseMessage httpResponse)
             {

--- a/src/version.props
+++ b/src/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Adds support for `Http (tracked component)` type. Uses `StartsWIth` instead of two hardcoded values for future compatibility (if somebody will decide to add another type :D )